### PR TITLE
fix(ssh-key): Fix the returned error on key parsing

### DIFF
--- a/loom.go
+++ b/loom.go
@@ -47,12 +47,12 @@ func parsekey(file string) (ssh.Signer, error) {
 	var private ssh.Signer
 	privateBytes, err := ioutil.ReadFile(file)
 	if err != nil {
-		return private, err
+		return nil, err
 	}
 
 	private, err = ssh.ParsePrivateKey(privateBytes)
 	if err != nil {
-		return private, nil
+		return nil, err
 	}
 	return private, nil
 }


### PR DESCRIPTION
The second line tweak is the more important one.
