### PR TITLE
Replace deprecated code.google.com import

### DIFF
--- a/loom.go
+++ b/loom.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"sync"
 
-	"code.google.com/p/go.crypto/ssh"
+	"golang.org/x/crypto/ssh"
 )
 
 // Config contains ssh and other configuration data needed for all the public functions in loom.


### PR DESCRIPTION
Starting with go 1.5, running `go get github.com/wingedpig/loom` gives a warning saying code.google.com is shutting down.
